### PR TITLE
commit by 康源 on 2016-05-19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node_modules
 # 自定义
 dist
 global.product.json
+
+# OS X System File
+.DS_Store

--- a/app.js
+++ b/app.js
@@ -106,7 +106,8 @@ const setupRoute = function(routeName) {
 
 [
     'root',
-    'news'
+    'news',
+    'story'
 ]
 .forEach(setupRoute);
 

--- a/routes/story/index.js
+++ b/routes/story/index.js
@@ -1,0 +1,110 @@
+
+'use strict';
+
+const logger=require('../../utils/logging');
+
+var routes = [];
+
+routes.push({
+    meta: {
+        name: 'getStories',
+        method: 'GET',
+        paths: [
+            '/story'
+        ],
+        version: '1.0.0'
+    },
+    action: function(req, res, next) {
+        res.send({
+            result: {
+                storyItems: [
+                    {sid: 1, content: '这是一个很有趣的故事'},
+                    {sid: 2, content: '这真的是一个很有趣的故事'}
+                ]
+            }
+        });
+        return next();
+    }
+});
+
+routes.push({
+    meta: {
+        name: 'getStoryById',
+        method: 'GET',
+        paths: [
+            '/story/:sid'
+        ],
+        version: '1.0.0'
+    },
+    action: function(req, res, next) {
+        var sid=req.params.sid;
+        res.send({
+            results: {
+                sid: sid,
+                content: '有趣的故事'+sid
+            }
+        });
+        return next();
+    }
+});
+
+routes.push({
+    meta: {
+        name: 'insertStory',
+        method: 'POST',
+        paths: [
+            '/story'
+        ],
+        version: '1.0.0'
+    },
+    action: function(req, res, next) {
+        res.send({
+            results: {
+                status: 'insert success' 
+            }
+        });
+        return next();
+    }
+});
+
+routes.push({
+    meta: {
+        name: 'deleteStory',
+        method: 'DELETE',
+        paths: [
+            '/story/:sid'
+        ],
+        version: '1.0.0'
+    },
+    action: function(req, res, next) {
+        res.send({
+            results: {
+                sid: req.params.sid,
+                status: 'delete success'
+            }
+        });
+        return next();
+    }
+});
+
+routes.push({
+    meta: {
+        name: 'updateStory',
+        method: 'PUT',
+        paths: [
+            '/story/:sid'
+        ],
+        version: '1.0.0'
+    },
+    action: function(req, res, next) {
+        res.send({
+            results: {
+                sid: req.params.sid,
+                status: 'update success'
+            } 
+        });
+        return next();
+    }
+});
+
+module.exports = routes;


### PR DESCRIPTION
修改：
1. 增加了/story路由，包括GET(select)、POST(insert)、PUT(update)、DELETE(delete)四种请求方式
2. 在.gitignore文件中添加了.DS_Store，防止Mac在文件下自动建立的非必要文件被提交

注：
暂时没有写测试用例..暂时对JavaScript的测试用例编写不太熟悉，但是使用了Postman发送模拟请求通过，返回了理想的结果
